### PR TITLE
Switch to fork with content length redirect

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "camo"]
 	path = camo
-	url = https://github.com/atmos/camo.git
+	url = https://github.com/di/camo.git
+	branch = content-length-redirect


### PR DESCRIPTION
This will switch us to my fork of camo (at least until [my PR is merged](https://github.com/atmos/camo/pull/139) or we replace it, whichever comes first), which allows us to set a redirect to a custom image when the user's image size exceeds the content length limit.

This will allow us to show a real image w/ some information in the README instead of just having a broken image with `404 Not Found` and no other information.

Also brings us up to the latest version, which doesn't really seem to have any functional changes and works fine in dev.