### PR TITLE
keep url.format() from choking in new four_oh_four method

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -279,7 +279,7 @@ server = Http.createServer (req, resp) ->
 
         process_url url, transferredHeaders, resp, max_redirects
       else
-        four_oh_four(resp, "checksum mismatch", "", "#{hmac_digest}:#{query_digest}")
+        four_oh_four(resp, "checksum mismatch", url, "#{hmac_digest}:#{query_digest}")
     else
       four_oh_four(resp, "No pathname provided on the server")
 

--- a/server.js
+++ b/server.js
@@ -320,7 +320,7 @@
           url = Url.parse(dest_url);
           return process_url(url, transferredHeaders, resp, max_redirects);
         } else {
-          return four_oh_four(resp, "checksum mismatch", "", hmac_digest + ":" + query_digest);
+          return four_oh_four(resp, "checksum mismatch", url, hmac_digest + ":" + query_digest);
         }
       } else {
         return four_oh_four(resp, "No pathname provided on the server");


### PR DESCRIPTION
carry on from #1, was running into:

```
pypi-camo-web-5d956c8874-7sbcq web /opt/camo/server.js:75
pypi-camo-web-5d956c8874-7sbcq web     error_log("" + msg + ((error != null) || '') + ": " + ((url != null ? url.format() : void 0) || 'unknown'));
pypi-camo-web-5d956c8874-7sbcq web                                                                               ^
pypi-camo-web-5d956c8874-7sbcq web 
pypi-camo-web-5d956c8874-7sbcq web TypeError: url.format is not a function
pypi-camo-web-5d956c8874-7sbcq web     at four_oh_four (/opt/camo/server.js:75:79)
pypi-camo-web-5d956c8874-7sbcq web     at Server.<anonymous> (/opt/camo/server.js:323:18)
pypi-camo-web-5d956c8874-7sbcq web     at emitTwo (events.js:126:13)
pypi-camo-web-5d956c8874-7sbcq web     at Server.emit (events.js:214:7)
pypi-camo-web-5d956c8874-7sbcq web     at parserOnIncoming (_http_server.js:619:12)
pypi-camo-web-5d956c8874-7sbcq web     at HTTPParser.parserOnHeadersComplete (_http_common.js:115:23)
```